### PR TITLE
feat: make bytes esm and umd consumable

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 .nyc_output
 coverage
 node_modules
+dist

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,10 @@
+module.exports = {
+  extends: 'kentcdodds',
+  rules: {
+    'func-names': 'off',
+    'prefer-exponentiation-operator': 'off',
+    'prefer-arrow-callback': 'off',
+    'no-bitwise': 'off',
+    'no-negated-condition': 'off'
+  }
+}

--- a/.npmignore
+++ b/.npmignore
@@ -3,4 +3,3 @@ coverage/
 node_modules/
 npm-debug.log
 package-lock.json
-dist

--- a/Readme.md
+++ b/Readme.md
@@ -1,3 +1,10 @@
+## Purpose of Existence Of This Fork
+
+1. The purpose of existence of this package/fork is to be able to be consumable as umd and esm modules, since the [author is not interested in suporting those environment](https://github.com/visionmedia/bytes.js/issues/64#issuecomment-1557245891), which is their humble choice.
+2. Intention of this package is to be in sync with the original repo and just give umd and esm modules as outputs along with the [original cjs](https://github.com/visionmedia/bytes.js).
+
+> ⚠️ Only PRs related to being in sync with the original repo will be enterntained. If you want to make a functional change, please raise issues and PRs in the original repo.
+
 # Bytes utility
 
 [![NPM Version][npm-image]][npm-url]
@@ -20,24 +27,24 @@ $ npm install bytes
 ## Usage
 
 ```js
-var bytes = require('bytes');
+var bytes = require("bytes");
 ```
 
-#### bytes(number｜string value, [options]): number｜string｜null
+#### bytes(number ｜ string value, [options]): number ｜ string ｜ null
 
 Default export function. Delegates to either `bytes.format` or `bytes.parse` based on the type of `value`.
 
 **Arguments**
 
-| Name    | Type     | Description        |
-|---------|----------|--------------------|
+| Name    | Type               | Description                                     |
+| ------- | ------------------ | ----------------------------------------------- |
 | value   | `number`｜`string` | Number value to format or string value to parse |
-| options | `Object` | Conversion options for `format` |
+| options | `Object`           | Conversion options for `format`                 |
 
 **Returns**
 
-| Name    | Type             | Description                                     |
-|---------|------------------|-------------------------------------------------|
+| Name    | Type                       | Description                                                                |
+| ------- | -------------------------- | -------------------------------------------------------------------------- |
 | results | `string`｜`number`｜`null` | Return null upon error. Numeric value in bytes, or string value otherwise. |
 
 **Example**
@@ -46,36 +53,36 @@ Default export function. Delegates to either `bytes.format` or `bytes.parse` bas
 bytes(1024);
 // output: '1KB'
 
-bytes('1KB');
+bytes("1KB");
 // output: 1024
 ```
 
-#### bytes.format(number value, [options]): string｜null
+#### bytes.format(number value, [options]): string ｜ null
 
 Format the given value in bytes into a string. If the value is negative, it is kept as such. If it is a float, it is
- rounded.
+rounded.
 
 **Arguments**
 
 | Name    | Type     | Description        |
-|---------|----------|--------------------|
+| ------- | -------- | ------------------ |
 | value   | `number` | Value in bytes     |
 | options | `Object` | Conversion options |
 
 **Options**
 
-| Property          | Type   | Description                                                                             |
-|-------------------|--------|-----------------------------------------------------------------------------------------|
-| decimalPlaces | `number`｜`null` | Maximum number of decimal places to include in output. Default value to `2`. |
-| fixedDecimals | `boolean`｜`null` | Whether to always display the maximum number of decimal places. Default value to `false` |
-| thousandsSeparator | `string`｜`null` | Example of values: `' '`, `','` and `'.'`... Default value to `''`. |
-| unit | `string`｜`null` | The unit in which the result will be returned (B/KB/MB/GB/TB). Default value to `''` (which means auto detect). |
-| unitSeparator | `string`｜`null` | Separator to use between number and unit. Default value to `''`. |
+| Property           | Type              | Description                                                                                                     |
+| ------------------ | ----------------- | --------------------------------------------------------------------------------------------------------------- |
+| decimalPlaces      | `number`｜`null`  | Maximum number of decimal places to include in output. Default value to `2`.                                    |
+| fixedDecimals      | `boolean`｜`null` | Whether to always display the maximum number of decimal places. Default value to `false`                        |
+| thousandsSeparator | `string`｜`null`  | Example of values: `' '`, `','` and `'.'`... Default value to `''`.                                             |
+| unit               | `string`｜`null`  | The unit in which the result will be returned (B/KB/MB/GB/TB). Default value to `''` (which means auto detect). |
+| unitSeparator      | `string`｜`null`  | Separator to use between number and unit. Default value to `''`.                                                |
 
 **Returns**
 
 | Name    | Type             | Description                                     |
-|---------|------------------|-------------------------------------------------|
+| ------- | ---------------- | ----------------------------------------------- |
 | results | `string`｜`null` | Return null upon error. String value otherwise. |
 
 **Example**
@@ -87,51 +94,51 @@ bytes.format(1024);
 bytes.format(1000);
 // output: '1000B'
 
-bytes.format(1000, {thousandsSeparator: ' '});
+bytes.format(1000, { thousandsSeparator: " " });
 // output: '1 000B'
 
-bytes.format(1024 * 1.7, {decimalPlaces: 0});
+bytes.format(1024 * 1.7, { decimalPlaces: 0 });
 // output: '2KB'
 
-bytes.format(1024, {unitSeparator: ' '});
+bytes.format(1024, { unitSeparator: " " });
 // output: '1 KB'
 ```
 
-#### bytes.parse(string｜number value): number｜null
+#### bytes.parse(string ｜ number value): number ｜ null
 
 Parse the string value into an integer in bytes. If no unit is given, or `value`
 is a number, it is assumed the value is in bytes.
 
 Supported units and abbreviations are as follows and are case-insensitive:
 
-  * `b` for bytes
-  * `kb` for kilobytes
-  * `mb` for megabytes
-  * `gb` for gigabytes
-  * `tb` for terabytes
-  * `pb` for petabytes
+- `b` for bytes
+- `kb` for kilobytes
+- `mb` for megabytes
+- `gb` for gigabytes
+- `tb` for terabytes
+- `pb` for petabytes
 
 The units are in powers of two, not ten. This means 1kb = 1024b according to this parser.
 
 **Arguments**
 
-| Name          | Type   | Description        |
-|---------------|--------|--------------------|
-| value   | `string`｜`number` | String to parse, or number in bytes.   |
+| Name  | Type               | Description                          |
+| ----- | ------------------ | ------------------------------------ |
+| value | `string`｜`number` | String to parse, or number in bytes. |
 
 **Returns**
 
-| Name    | Type        | Description             |
-|---------|-------------|-------------------------|
+| Name    | Type             | Description                                       |
+| ------- | ---------------- | ------------------------------------------------- |
 | results | `number`｜`null` | Return null upon error. Value in bytes otherwise. |
 
 **Example**
 
 ```js
-bytes.parse('1KB');
+bytes.parse("1KB");
 // output: 1024
 
-bytes.parse('1024');
+bytes.parse("1024");
 // output: 1024
 
 bytes.parse(1024);

--- a/index.js
+++ b/index.js
@@ -2,30 +2,20 @@
  * bytes
  * Copyright(c) 2012-2014 TJ Holowaychuk
  * Copyright(c) 2015 Jed Watson
+ * Copyright(c) 2023 Arihant Verma
  * MIT Licensed
  */
 
-'use strict';
-
 /**
- * Module exports.
- * @public
- */
-
-module.exports = bytes;
-module.exports.format = format;
-module.exports.parse = parse;
-
-/**
- * Module variables.
+ * Module letiables.
  * @private
  */
 
-var formatThousandsRegExp = /\B(?=(\d{3})+(?!\d))/g;
+const formatThousandsRegExp = /\B(?=(\d{3})+(?!\d))/g;
 
-var formatDecimalsRegExp = /(?:\.0*|(\.[^0]+)0+)$/;
+const formatDecimalsRegExp = /(?:\.0*|(\.[^0]+)0+)$/;
 
-var map = {
+const map = {
   b:  1,
   kb: 1 << 10,
   mb: 1 << 20,
@@ -34,7 +24,7 @@ var map = {
   pb: Math.pow(1024, 5),
 };
 
-var parseRegExp = /^((-|\+)?(\d+(?:\.\d+)?)) *(kb|mb|gb|tb|pb)$/i;
+const parseRegExp = /^((-|\+)?(\d+(?:\.\d+)?)) *(kb|mb|gb|tb|pb)$/i;
 
 /**
  * Convert the given value in bytes into a string or parse to string to an integer in bytes.
@@ -51,7 +41,7 @@ var parseRegExp = /^((-|\+)?(\d+(?:\.\d+)?)) *(kb|mb|gb|tb|pb)$/i;
  * @returns {string|number|null}
  */
 
-function bytes(value, options) {
+export function bytes(value, options) {
   if (typeof value === 'string') {
     return parse(value);
   }
@@ -81,17 +71,17 @@ function bytes(value, options) {
  * @public
  */
 
-function format(value, options) {
+export function format(value, options) {
   if (!Number.isFinite(value)) {
     return null;
   }
 
-  var mag = Math.abs(value);
-  var thousandsSeparator = (options && options.thousandsSeparator) || '';
-  var unitSeparator = (options && options.unitSeparator) || '';
-  var decimalPlaces = (options && options.decimalPlaces !== undefined) ? options.decimalPlaces : 2;
-  var fixedDecimals = Boolean(options && options.fixedDecimals);
-  var unit = (options && options.unit) || '';
+  const mag = Math.abs(value);
+  const thousandsSeparator = (options && options.thousandsSeparator) || '';
+  const unitSeparator = (options && options.unitSeparator) || '';
+  const decimalPlaces = (options && options.decimalPlaces !== undefined) ? options.decimalPlaces : 2;
+  const fixedDecimals = Boolean(options && options.fixedDecimals);
+  let unit = (options && options.unit) || '';
 
   if (!unit || !map[unit.toLowerCase()]) {
     if (mag >= map.pb) {
@@ -109,8 +99,8 @@ function format(value, options) {
     }
   }
 
-  var val = value / map[unit.toLowerCase()];
-  var str = val.toFixed(decimalPlaces);
+  const val = value / map[unit.toLowerCase()];
+  let str = val.toFixed(decimalPlaces);
 
   if (!fixedDecimals) {
     str = str.replace(formatDecimalsRegExp, '$1');
@@ -138,7 +128,7 @@ function format(value, options) {
  * @public
  */
 
-function parse(val) {
+export function parse(val) {
   if (typeof val === 'number' && !isNaN(val)) {
     return val;
   }
@@ -148,9 +138,9 @@ function parse(val) {
   }
 
   // Test if the string passed is valid
-  var results = parseRegExp.exec(val);
-  var floatValue;
-  var unit = 'b';
+  const results = parseRegExp.exec(val);
+  let floatValue;
+  let unit = 'b';
 
   if (!results) {
     // Nothing could be extracted from the given string
@@ -168,3 +158,5 @@ function parse(val) {
 
   return Math.floor(map[unit] * floatValue);
 }
+
+

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
-  "name": "bytes",
+  "name": "@arihantverma/bytes.js",
   "description": "Utility to parse a string bytes to bytes and vice-versa",
   "version": "3.1.2",
   "author": "TJ Holowaychuk <tj@vision-media.ca> (http://tjholowaychuk.com)",
   "contributors": [
     "Jed Watson <jed.watson@me.com>",
-    "Théo FIDRY <theo.fidry@gmail.com>"
+    "Théo FIDRY <theo.fidry@gmail.com>",
+    "Arihant Verma<arihantverma1994@gmail.com,arihantverma@proton.me>"
   ],
   "license": "MIT",
   "keywords": [
@@ -17,10 +18,12 @@
     "convert",
     "converter"
   ],
-  "repository": "visionmedia/bytes.js",
+  "repository": "arihantverma/bytes.js",
   "devDependencies": {
-    "eslint": "7.32.0",
-    "eslint-plugin-markdown": "2.2.1",
+    "eslint": "8.41.0",
+    "eslint-config-kentcdodds": "^20.5.0",
+    "eslint-plugin-markdown": "3.0.0",
+    "microbundle": "^0.15.1",
     "mocha": "9.2.0",
     "nyc": "15.1.0"
   },
@@ -28,7 +31,8 @@
     "History.md",
     "LICENSE",
     "Readme.md",
-    "index.js"
+    "index.js",
+    "dist/**/*"
   ],
   "engines": {
     "node": ">= 0.8"
@@ -37,6 +41,17 @@
     "lint": "eslint .",
     "test": "mocha --check-leaks --reporter spec",
     "test-ci": "nyc --reporter=lcov --reporter=text npm test",
-    "test-cov": "nyc --reporter=html --reporter=text npm test"
+    "test-cov": "nyc --reporter=html --reporter=text npm test",
+    "build": "microbundle",
+    "publish": "npm run build && npm publish --access public"
+  },
+  "type": "module",
+  "source": "./index.js",
+  "main": "dist/index.cjs",
+  "umd:main": "dist/foo.umd.js",
+  "module": "dist/foo.js",
+  "exports": {
+    "require": "./dist/foo.js",
+    "default": "./dist/foo.modern.mjs"
   }
 }

--- a/test/byte-format.js
+++ b/test/byte-format.js
@@ -1,119 +1,176 @@
-'use strict';
+const assert = require("assert");
+const bytes = require("..");
 
-var assert = require('assert');
-var bytes = require('..');
+describe("Test byte format function", function () {
+  const pb = Math.pow(1024, 5);
+  const tb = (1 << 30) * 1024;
+  const gb = 1 << 30;
+  const mb = 1 << 20;
+  const kb = 1 << 10;
 
-describe('Test byte format function', function(){
-  var pb = Math.pow(1024, 5);
-  var tb = (1 << 30) * 1024,
-    gb = 1 << 30,
-    mb = 1 << 20,
-    kb = 1 << 10;
-
-  it('Should return null if input is invalid', function(){
+  it("Should return null if input is invalid", function () {
     assert.strictEqual(bytes.format(undefined), null);
     assert.strictEqual(bytes.format(null), null);
     assert.strictEqual(bytes.format(true), null);
     assert.strictEqual(bytes.format(false), null);
     assert.strictEqual(bytes.format(NaN), null);
     assert.strictEqual(bytes.format(Infinity), null);
-    assert.strictEqual(bytes.format(''), null);
-    assert.strictEqual(bytes.format('string'), null);
-    assert.strictEqual(bytes.format(function(){}), null);
+    assert.strictEqual(bytes.format(""), null);
+    assert.strictEqual(bytes.format("string"), null);
+    assert.strictEqual(
+      bytes.format(function () {}),
+      null
+    );
     assert.strictEqual(bytes.format({}), null);
   });
 
-  it('Should convert numbers < 1024 to `bytes` string', function(){
-    assert.equal(bytes.format(0).toLowerCase(), '0b');
-    assert.equal(bytes.format(100).toLowerCase(), '100b');
-    assert.equal(bytes.format(-100).toLowerCase(), '-100b');
+  it("Should convert numbers < 1024 to `bytes` string", function () {
+    assert.equal(bytes.format(0).toLowerCase(), "0b");
+    assert.equal(bytes.format(100).toLowerCase(), "100b");
+    assert.equal(bytes.format(-100).toLowerCase(), "-100b");
   });
 
-  it('Should convert numbers >= 1 024 to kb string', function(){
-    assert.equal(bytes.format(kb).toLowerCase(), '1kb');
-    assert.equal(bytes.format(-kb).toLowerCase(), '-1kb');
-    assert.equal(bytes.format(2 * kb).toLowerCase(), '2kb');
+  it("Should convert numbers >= 1 024 to kb string", function () {
+    assert.equal(bytes.format(kb).toLowerCase(), "1kb");
+    assert.equal(bytes.format(-kb).toLowerCase(), "-1kb");
+    assert.equal(bytes.format(2 * kb).toLowerCase(), "2kb");
   });
 
-  it('Should convert numbers >= 1 048 576 to mb string', function(){
-    assert.equal(bytes.format(mb).toLowerCase(), '1mb');
-    assert.equal(bytes.format(-mb).toLowerCase(), '-1mb');
-    assert.equal(bytes.format(2 * mb).toLowerCase(), '2mb');
+  it("Should convert numbers >= 1 048 576 to mb string", function () {
+    assert.equal(bytes.format(mb).toLowerCase(), "1mb");
+    assert.equal(bytes.format(-mb).toLowerCase(), "-1mb");
+    assert.equal(bytes.format(2 * mb).toLowerCase(), "2mb");
   });
 
-  it('Should convert numbers >= (1 << 30) to gb string', function(){
-    assert.equal(bytes.format(gb).toLowerCase(), '1gb');
-    assert.equal(bytes.format(-gb).toLowerCase(), '-1gb');
-    assert.equal(bytes.format(2 * gb).toLowerCase(), '2gb');
+  it("Should convert numbers >= (1 << 30) to gb string", function () {
+    assert.equal(bytes.format(gb).toLowerCase(), "1gb");
+    assert.equal(bytes.format(-gb).toLowerCase(), "-1gb");
+    assert.equal(bytes.format(2 * gb).toLowerCase(), "2gb");
   });
 
-  it('Should convert numbers >= ((1 << 30) * 1024) to tb string', function(){
-    assert.equal(bytes.format(tb).toLowerCase(), '1tb');
-    assert.equal(bytes.format(-tb).toLowerCase(), '-1tb');
-    assert.equal(bytes.format(2 * tb).toLowerCase(), '2tb');
+  it("Should convert numbers >= ((1 << 30) * 1024) to tb string", function () {
+    assert.equal(bytes.format(tb).toLowerCase(), "1tb");
+    assert.equal(bytes.format(-tb).toLowerCase(), "-1tb");
+    assert.equal(bytes.format(2 * tb).toLowerCase(), "2tb");
   });
 
-  it('Should convert numbers >= 1 125 899 906 842 624 to pb string', function(){
-    assert.equal(bytes.format(pb).toLowerCase(), '1pb');
-    assert.equal(bytes.format(-pb).toLowerCase(), '-1pb');
-    assert.equal(bytes.format(2 * pb).toLowerCase(), '2pb');
+  it("Should convert numbers >= 1 125 899 906 842 624 to pb string", function () {
+    assert.equal(bytes.format(pb).toLowerCase(), "1pb");
+    assert.equal(bytes.format(-pb).toLowerCase(), "-1pb");
+    assert.equal(bytes.format(2 * pb).toLowerCase(), "2pb");
   });
 
-  it('Should return standard case', function(){
-    assert.equal(bytes.format(10), '10B');
-    assert.equal(bytes.format(kb), '1KB');
-    assert.equal(bytes.format(mb), '1MB');
-    assert.equal(bytes.format(gb), '1GB');
-    assert.equal(bytes.format(tb), '1TB');
-    assert.equal(bytes.format(pb), '1PB');
+  it("Should return standard case", function () {
+    assert.equal(bytes.format(10), "10B");
+    assert.equal(bytes.format(kb), "1KB");
+    assert.equal(bytes.format(mb), "1MB");
+    assert.equal(bytes.format(gb), "1GB");
+    assert.equal(bytes.format(tb), "1TB");
+    assert.equal(bytes.format(pb), "1PB");
   });
 
-  it('Should support custom thousands separator', function(){
-    assert.equal(bytes.format(1000).toLowerCase(), '1000b');
-    assert.equal(bytes.format(1000, {thousandsSeparator: ''}).toLowerCase(), '1000b');
-    assert.equal(bytes.format(1000, {thousandsSeparator: null}).toLowerCase(), '1000b');
-    assert.equal(bytes.format(1000, {thousandsSeparator: '.'}).toLowerCase(), '1.000b');
-    assert.equal(bytes.format(1000, {thousandsSeparator: ','}).toLowerCase(), '1,000b');
-    assert.equal(bytes.format(1000, {thousandsSeparator: ' '}).toLowerCase(), '1 000b');
-    assert.equal(bytes.format(1005.1005 * kb, {decimalPlaces: 4, thousandsSeparator: '_'}).toLowerCase(), '1_005.1005kb');
+  it("Should support custom thousands separator", function () {
+    assert.equal(bytes.format(1000).toLowerCase(), "1000b");
+    assert.equal(
+      bytes.format(1000, { thousandsSeparator: "" }).toLowerCase(),
+      "1000b"
+    );
+    assert.equal(
+      bytes.format(1000, { thousandsSeparator: null }).toLowerCase(),
+      "1000b"
+    );
+    assert.equal(
+      bytes.format(1000, { thousandsSeparator: "." }).toLowerCase(),
+      "1.000b"
+    );
+    assert.equal(
+      bytes.format(1000, { thousandsSeparator: "," }).toLowerCase(),
+      "1,000b"
+    );
+    assert.equal(
+      bytes.format(1000, { thousandsSeparator: " " }).toLowerCase(),
+      "1 000b"
+    );
+    assert.equal(
+      bytes
+        .format(1005.1005 * kb, { decimalPlaces: 4, thousandsSeparator: "_" })
+        .toLowerCase(),
+      "1_005.1005kb"
+    );
   });
 
-  it('Should support custom unit separator', function(){
-    assert.equal(bytes.format(1024), '1KB');
-    assert.equal(bytes.format(1024, {unitSeparator: ''}), '1KB');
-    assert.equal(bytes.format(1024, {unitSeparator: null}), '1KB');
-    assert.equal(bytes.format(1024, {unitSeparator: ' '}), '1 KB');
-    assert.equal(bytes.format(1024, {unitSeparator: '\t'}), '1\tKB');
+  it("Should support custom unit separator", function () {
+    assert.equal(bytes.format(1024), "1KB");
+    assert.equal(bytes.format(1024, { unitSeparator: "" }), "1KB");
+    assert.equal(bytes.format(1024, { unitSeparator: null }), "1KB");
+    assert.equal(bytes.format(1024, { unitSeparator: " " }), "1 KB");
+    assert.equal(bytes.format(1024, { unitSeparator: "\t" }), "1\tKB");
   });
 
-  it('Should support custom number of decimal places', function(){
-    assert.equal(bytes.format(kb - 1, {decimalPlaces: 0}).toLowerCase(), '1023b');
-    assert.equal(bytes.format(kb, {decimalPlaces: 0}).toLowerCase(), '1kb');
-    assert.equal(bytes.format(1.4 * kb, {decimalPlaces: 0}).toLowerCase(), '1kb');
-    assert.equal(bytes.format(1.5 * kb, {decimalPlaces: 0}).toLowerCase(), '2kb');
-    assert.equal(bytes.format(kb - 1, {decimalPlaces: 1}).toLowerCase(), '1023b');
-    assert.equal(bytes.format(kb, {decimalPlaces: 1}).toLowerCase(), '1kb');
-    assert.equal(bytes.format(1.04 * kb, {decimalPlaces: 1}).toLowerCase(), '1kb');
-    assert.equal(bytes.format(1.05 * kb, {decimalPlaces: 1}).toLowerCase(), '1.1kb');
-    assert.equal(bytes.format(1.1005 * kb, {decimalPlaces: 4}).toLowerCase(), '1.1005kb');
+  it("Should support custom number of decimal places", function () {
+    assert.equal(
+      bytes.format(kb - 1, { decimalPlaces: 0 }).toLowerCase(),
+      "1023b"
+    );
+    assert.equal(bytes.format(kb, { decimalPlaces: 0 }).toLowerCase(), "1kb");
+    assert.equal(
+      bytes.format(1.4 * kb, { decimalPlaces: 0 }).toLowerCase(),
+      "1kb"
+    );
+    assert.equal(
+      bytes.format(1.5 * kb, { decimalPlaces: 0 }).toLowerCase(),
+      "2kb"
+    );
+    assert.equal(
+      bytes.format(kb - 1, { decimalPlaces: 1 }).toLowerCase(),
+      "1023b"
+    );
+    assert.equal(bytes.format(kb, { decimalPlaces: 1 }).toLowerCase(), "1kb");
+    assert.equal(
+      bytes.format(1.04 * kb, { decimalPlaces: 1 }).toLowerCase(),
+      "1kb"
+    );
+    assert.equal(
+      bytes.format(1.05 * kb, { decimalPlaces: 1 }).toLowerCase(),
+      "1.1kb"
+    );
+    assert.equal(
+      bytes.format(1.1005 * kb, { decimalPlaces: 4 }).toLowerCase(),
+      "1.1005kb"
+    );
   });
 
-  it('Should support fixed decimal places', function(){
-    assert.equal(bytes.format(kb, {decimalPlaces: 3, fixedDecimals: true}).toLowerCase(), '1.000kb');
+  it("Should support fixed decimal places", function () {
+    assert.equal(
+      bytes.format(kb, { decimalPlaces: 3, fixedDecimals: true }).toLowerCase(),
+      "1.000kb"
+    );
   });
 
-  it('Should support floats', function(){
-    assert.equal(bytes.format(1.2 * mb).toLowerCase(), '1.2mb');
-    assert.equal(bytes.format(-1.2 * mb).toLowerCase(), '-1.2mb');
-    assert.equal(bytes.format(1.2 * kb).toLowerCase(), '1.2kb');
-  })
+  it("Should support floats", function () {
+    assert.equal(bytes.format(1.2 * mb).toLowerCase(), "1.2mb");
+    assert.equal(bytes.format(-1.2 * mb).toLowerCase(), "-1.2mb");
+    assert.equal(bytes.format(1.2 * kb).toLowerCase(), "1.2kb");
+  });
 
-  it('Should support custom unit', function(){
-    assert.equal(bytes.format(12 * mb, {unit: 'b'}).toLowerCase(), '12582912b');
-    assert.equal(bytes.format(12 * mb, {unit: 'kb'}).toLowerCase(), '12288kb');
-    assert.equal(bytes.format(12 * gb, {unit: 'mb'}).toLowerCase(), '12288mb');
-    assert.equal(bytes.format(12 * tb, {unit: 'gb'}).toLowerCase(), '12288gb');
-    assert.equal(bytes.format(12 * mb, {unit: ''}).toLowerCase(), '12mb');
-    assert.equal(bytes.format(12 * mb, {unit: 'bb'}).toLowerCase(), '12mb');
-  })
+  it("Should support custom unit", function () {
+    assert.equal(
+      bytes.format(12 * mb, { unit: "b" }).toLowerCase(),
+      "12582912b"
+    );
+    assert.equal(
+      bytes.format(12 * mb, { unit: "kb" }).toLowerCase(),
+      "12288kb"
+    );
+    assert.equal(
+      bytes.format(12 * gb, { unit: "mb" }).toLowerCase(),
+      "12288mb"
+    );
+    assert.equal(
+      bytes.format(12 * tb, { unit: "gb" }).toLowerCase(),
+      "12288gb"
+    );
+    assert.equal(bytes.format(12 * mb, { unit: "" }).toLowerCase(), "12mb");
+    assert.equal(bytes.format(12 * mb, { unit: "bb" }).toLowerCase(), "12mb");
+  });
 });

--- a/test/byte-parse.js
+++ b/test/byte-parse.js
@@ -1,7 +1,5 @@
-'use strict';
-
-var assert = require('assert');
-var bytes = require('..');
+const assert = require('assert');
+const bytes = require('..');
 
 describe('Test byte parse function', function(){
   it('Should return null if input is invalid', function(){

--- a/test/bytes.js
+++ b/test/bytes.js
@@ -1,7 +1,5 @@
-'use strict';
-
-var assert = require('assert');
-var bytes = require('../index.js');
+const assert = require('assert');
+const bytes = require('../index.js');
 
 describe('Test constructor', function(){
   it('Expect a function', function(){


### PR DESCRIPTION
# feat: make bytes esm and umd consumable

- add a separate eslint configuration ( Kent C Dodds ) and quick changes to cater to some meaningful rules, while overriding the rules which don't make sense for this codebase.
- configure [microbundle](https://github.com/developit/microbundle) to emit cjs, umd and esm modules in `dist` folder.